### PR TITLE
adding google search console verification snippet

### DIFF
--- a/src/_includes/layouts/default.njk
+++ b/src/_includes/layouts/default.njk
@@ -25,6 +25,8 @@
     {% if site.google_analytics %}
       {% include "partials/analytics.njk" %}
     {% endif %}
+    
+    <meta name="google-site-verification" content="RMV-cjpAWkM-B69Nn0Pc-3hqjZzD8rKr6zpzm0Zhlak" />
   </head>
 
   <body class="{% if page.slug %}{{ page.slug }}{% endif %}">


### PR DESCRIPTION
adding HTML metatag snippet for google search console verification, for this subdomain property.
![functions.netlify.com GSC verification screenshot](https://user-images.githubusercontent.com/25587929/108238487-3ce03080-7106-11eb-930e-92f2df076a4a.png)
