### PR TITLE
hardcode the root url for sitemap

### DIFF
--- a/src/_data/site.js
+++ b/src/_data/site.js
@@ -10,7 +10,7 @@ module.exports = {
   image: "/assets/images/logos/logo.png",
 
   parentUrl: "https://netlify.com",
-  url: URL,
+  url: "https://functions.netlify.com",
   logo: "/assets/images/logos/logo.svg",
   logoChild: "/assets/images/logos/functions.svg",
   lang: "en-US",


### PR DESCRIPTION
https://functions.netlify.com/sitemap.xml should now show the correct root URL instead of detecting the netlify.app domain.