### PR TITLE
Create a featured section and move down all examples with the search

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -87,6 +87,11 @@ module.exports = function (eleventyConfig) {
     return [...data].sort();
   });
 
+  // Filter a collection based on items flagged as "featured"
+  eleventyConfig.addFilter("featured", (items) => {
+    return items.filter((item) => item.data.featured);
+  });
+
   // If string contains a certain string
   eleventyConfig.addFilter(
     "contains",

--- a/src/_includes/layouts/example.njk
+++ b/src/_includes/layouts/example.njk
@@ -25,7 +25,7 @@
 
     {% if readme %}
       <section class="section section--readme">
-        <h3 id="readme">Readme</h3>
+        <h3 class="section__heading" id="readme">Readme</h3>
         {{ readme | markdownify | safe }}
       </section>
     {% endif %}
@@ -34,7 +34,7 @@
 
     {% if related.length > 1 %}
       <section class="section section--related">
-        <h3>Related examples</h3>
+        <h3 class="section__heading">Related examples</h3>
         <ul class="examples  examples--related" role="list">
           {% for item in related %}
             {% if loop.index0 < 2 and item.url != page.url %}

--- a/src/_includes/layouts/examples.njk
+++ b/src/_includes/layouts/examples.njk
@@ -12,17 +12,31 @@
       <a href="https://github.com/{{ pkg.repository }}/issues/new" class="button">Add a function example</a>
     </header>
 
+    {% if (collections.examples | featured).length %}
+      <section class="section section--examples section--featured">
+        <h2 class="section__heading">Featured</h2>
+        {{ examples({
+          examples: collections.examples | featured,
+          githubData: githubData,
+          ariaLive: true
+        }) }}
+      </section>
+    {% endif %}
+
     {{ search({
       searchForm: true,
       backButton: false,
       collections: collections
     }) }}
 
-    {{ examples({
-      examples: collections.examples,
-      githubData: githubData,
-      ariaLive: true
-    }) }}
+    <section class="section section--examples" data-search-section="">
+      <h2 class="section__heading">All examples</h2>
+      {{ examples({
+        examples: collections.examples,
+        githubData: githubData,
+        ariaLive: true
+      }) }}
+    </section>
   </main>
   {% include "partials/sidebar.njk" %}
 {% endblock %}

--- a/src/assets/css/_main.scss
+++ b/src/assets/css/_main.scss
@@ -58,22 +58,41 @@
   }
 }
 
-// Sections such as Readme and Related functions
+// Sections such as Readme, Related functions, Featured examples and All examples
 .section {
-  margin-top: 1rem;
-  padding-top: 1rem;
-  border-top: 1px solid darken($color__primary--lightest, 5%);
+  &--examples {
+    display: grid;
+    grid-row-gap: 1rem;
+  }
 
-  h3 {
-    margin-top: 0;
+  &--featured {
+    padding-bottom: 3rem;
+    margin-bottom: 1rem;
+    border-bottom: 1px solid darken($color__primary--lightest, 5%);
+  }
+
+  &--readme,
+  &--related {
+    margin-top: 1rem;
+    padding-top: 1rem;
+    border-top: 1px solid darken($color__primary--lightest, 5%);
   }
 
   &--readme h3 + * {
     margin-top: 1rem;
   }
-  
+
   &--related {
     margin-top: 4rem;
   }
-  
+
+  &__heading {
+    margin-top: 0;
+    color: $color__neutral--mid;
+  }
+}
+
+// Hide headings when there's no items that match the search criteria
+[data-search-section-count="0"] .section__heading {
+  display: none;
 }

--- a/src/assets/js/scripts.js
+++ b/src/assets/js/scripts.js
@@ -1,6 +1,6 @@
 function hideUnmatched({ items, field, emptyMessage }) {
   // Make sure everything is visible
-  items.forEach(item => {
+  items.forEach((item) => {
     item.dataset.searchVisibility = "visible";
     item.removeAttribute("hidden");
   });
@@ -9,7 +9,7 @@ function hideUnmatched({ items, field, emptyMessage }) {
   emptyMessage.setAttribute("hidden", "");
 
   // Filter out the unmatched items
-  const unmatchedItems = items.filter(item => {
+  const unmatchedItems = items.filter((item) => {
     return !item
       .querySelector(".card__title")
       .textContent.toLowerCase()
@@ -17,7 +17,7 @@ function hideUnmatched({ items, field, emptyMessage }) {
   });
 
   // Hide the unmatched items
-  unmatchedItems.forEach(item => {
+  unmatchedItems.forEach((item) => {
     item.dataset.searchVisibility = "hidden";
     item.setAttribute("hidden", "");
   });
@@ -25,6 +25,13 @@ function hideUnmatched({ items, field, emptyMessage }) {
   if (items.length === unmatchedItems.length) {
     emptyMessage.removeAttribute("hidden");
   }
+}
+
+// Append to example sections a count of items that are matching the search criteria
+function appandItemSectionCount({ searchSection }) {
+  searchSection.dataset.searchSectionCount = searchSection.querySelectorAll(
+    "[data-search-visibility='visible']"
+  ).length;
 }
 
 // Grab the form
@@ -35,18 +42,20 @@ if (form) {
   // Grab all elements needed
   const emptyMessage = document.querySelector("[data-search-empty-message]");
   const field = form.querySelector("input[type='search']");
-  const items = [...document.querySelectorAll("[data-search-visibility]")];
+  const searchSection = document.querySelector("[data-search-section]");
+  const items = [...searchSection.querySelectorAll("[data-search-visibility]")];
 
   // Display search when js runs
   form.dataset.search = "enabled";
 
   // Listen for typing in the search field
-  field.addEventListener("keyup", () =>
-    hideUnmatched({ items, field, emptyMessage })
-  );
+  field.addEventListener("keyup", () => {
+    hideUnmatched({ items, field, emptyMessage });
+    appandItemSectionCount({ searchSection });
+  });
 
   // Prevent enter from submitting the form
-  field.addEventListener("keydown", function(event) {
+  field.addEventListener("keydown", function (event) {
     if (event.key === "Enter") {
       event.preventDefault();
     }

--- a/src/examples/airtable-get-request-(single-record-response-with-record-id-in-query-string-or-first-20-without).md
+++ b/src/examples/airtable-get-request-(single-record-response-with-record-id-in-query-string-or-first-20-without).md
@@ -2,7 +2,8 @@
 title: Airtable GET request (single record response with Record ID in query string or first 20 without)
 code: scottbram/CinemaTron/blob/prod/functions/at_get_movie.js
 url: scottbram/CinemaTron/
-tags: 
+featured: true
+tags:
   - airtable
   - javascript
 ---
@@ -12,5 +13,6 @@ tags:
 This working sample will return a single record in the response when a query string value is present (from the key &quot;recid&quot;) or will return the first 20 records when no query string value is present.
 
 Notes:
+
 - Performs no validation on the record ID; invalid values will meet the catch condition
 - A sort configuration (by field &quot;Year&quot;) is present, which may simply be omitted or revised to your need

--- a/src/examples/create-react-app-lambda.md
+++ b/src/examples/create-react-app-lambda.md
@@ -1,7 +1,8 @@
 ---
 title: create-react-app-lambda
 code: netlify/create-react-app-lambda
-tags: 
+featured: true
+tags:
   - react
   - starter
 ---

--- a/src/examples/netlify-functions-crud-app-with-fauna.md
+++ b/src/examples/netlify-functions-crud-app-with-fauna.md
@@ -1,7 +1,8 @@
 ---
 title: netlify-functions-crud-app-with-fauna
 code: netlify/netlify-faunadb-example
-tags: 
+featured: true
+tags:
   - database
   - fauna
   - CRUD
@@ -9,4 +10,4 @@ tags:
 
 # netlify-functions-crud-app-with-fauna
 
-Using faunaDB as datastore 
+Using faunaDB as datastore


### PR DESCRIPTION
This change moves the "all examples" section down along with the search and inserts a featured section above. Examples flagged with `featured: true` will appear in this section. If there are no featured examples the section won't show at all.

Fixes daviddarnes/functions.netlify.com#13