### PR TITLE
[FIX] Update wrong code url

### DIFF
--- a/src/examples/ifttt-to-flick-instagram-make-new-github-post.md
+++ b/src/examples/ifttt-to-flick-instagram-make-new-github-post.md
@@ -1,7 +1,7 @@
 ---
 title: ifttt-to-flick-instagram-make-new-github-post
 code:
-  - https://github.com/rretsiem/renem.net/blob/574b1c5091e993b520e23f993a6c46069e92cdb0/src/functions
+  - rretsiem/renem.net/blob/574b1c5091e993b520e23f993a6c46069e92cdb0/src/functions
 url: https://renem.net/photos/
 tags:
   - instagram


### PR DESCRIPTION
The code urls was wrong in ifttt-to-flick-instagram-make-new-github-post.md function, its no necesary set the github domain.

Issue https://github.com/netlify/functions/issues/72