### PR TITLE
chore: add fossa license scanning

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -35,4 +35,3 @@ jobs:
         run: fossa analyze --debug
         env:
           FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
-


### PR DESCRIPTION
NOTICE: If this pull request does not apply to your repository, feel free to close this pull request. This is a pull request generated by [github-tools](https://github.com/netlify/github-tools/) to add Fossa license scanning to this repository. For more information about what FOSSA is and whether your repository needs it, check out the [documentation](https://www.notion.so/netlify/FOSSA-Dependency-License-Scanning-and-Analysis-62ffbb2817b5400ea32e97738d26cd30).

You can check the status of your scan at https://app.fossa.com/projects/custom%2B17679%2Fgit%40github.com%3Anetlify%2FYOUR_PROJECT.git (replace **YOUR_PROJECT** with the name of your repository). If you have any questions or issues related to this (or if you are unable to access the Fossa report), please contact us on slack at #crew-internal-tools. 

The Fossa status check will **fail** until some code has been added to your default branch. **If the status check for FOSSA is failing, wait until you have merged some code into your default branch and rerun the workflow. If the workflow passes, this PR is safe to merge.**