### PR TITLE
chore: fix first release PR version

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,3 +12,4 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           release-type: node
           package-name: '@netlify/netlify-functions-js'
+          bump-minor-pre-major: true


### PR DESCRIPTION
This should start the versioning from `0.1.0`