### PR TITLE
chore(renovate): enable automerge

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -3,7 +3,7 @@
   ignorePresets: [':prHourlyLimit2'],
   semanticCommits: true,
   masterIssue: true,
-  automerge: false,
+  automerge: true,
   packageRules: [
     {
       // Those cannot be upgraded to a major version until we drop support for Node 8


### PR DESCRIPTION
Enables renovate automerge.

I've requested to install https://github.com/apps/renovate-approve for the repo (though I don't think it's required since it seems we don't have any branch protection rules)