### PR TITLE
fix: make `Response.body` optional

### DIFF
--- a/src/function/response.d.ts
+++ b/src/function/response.d.ts
@@ -6,6 +6,6 @@ export interface Response {
   multiValueHeaders?: {
     [header: string]: ReadonlyArray<boolean | number | string>
   }
-  body: string
+  body?: string
   isBase64Encoded?: boolean
 }


### PR DESCRIPTION
**Which problem is this pull request solving?**

Makes the `body` property in `Response` optional.

**List other issues or pull requests related to this problem**

Closes #57.

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../blob/master/CONTRIBUTING.md).
- [ ] The status checks are successful (continuous integration). Those can be seen below.
