### PR TITLE
fix(handler type): make callback parameter optional

### DIFF
--- a/src/function/handler.ts
+++ b/src/function/handler.ts
@@ -8,7 +8,7 @@ export interface HandlerCallback<ResponseType extends Response = Response> {
 }
 
 export interface BaseHandler<ResponseType extends Response = Response, C extends Context = Context> {
-  (event: Event, context: C, callback: HandlerCallback<ResponseType>): void | ResponseType | Promise<ResponseType>
+  (event: Event, context: C, callback?: HandlerCallback<ResponseType>): void | ResponseType | Promise<ResponseType>
 }
 
 export type Handler = BaseHandler<Response, Context>

--- a/src/lib/builder.ts
+++ b/src/lib/builder.ts
@@ -21,7 +21,7 @@ const augmentResponse = (response: BuilderResponse) => {
 const wrapHandler =
   (handler: BuilderHandler): Handler =>
   // eslint-disable-next-line promise/prefer-await-to-callbacks
-  (event: HandlerEvent, context: HandlerContext, callback: HandlerCallback<Response>) => {
+  (event: HandlerEvent, context: HandlerContext, callback?: HandlerCallback<Response>) => {
     if (event.httpMethod !== 'GET' && event.httpMethod !== 'HEAD') {
       return Promise.resolve({
         body: 'Method Not Allowed',
@@ -37,7 +37,7 @@ const wrapHandler =
     }
 
     // eslint-disable-next-line promise/prefer-await-to-callbacks
-    const wrappedCallback = (error: unknown, response: BuilderResponse) => callback(error, augmentResponse(response))
+    const wrappedCallback = (error: unknown, response: BuilderResponse) => callback?.(error, augmentResponse(response))
     const execution = handler(modifiedEvent, context, wrappedCallback)
 
     if (isPromise(execution)) {


### PR DESCRIPTION
🎉 Thanks for sending this pull request! 🎉

Please make sure the title is clear and descriptive.

If you are fixing a typo or documentation, please skip these instructions.

Otherwise please fill in the sections below.

**Which problem is this pull request solving?**

- Callbacks are not necessary when executing CRUD handlers. This is making the migration from JS Netlify functions to TS exceedingly difficult. I have to pass empty functions everywhere I call a handler (`() => {}`) which is violating the common ESLint rule for no empty arrow functions.

**List other issues or pull requests related to this problem**

n/a

**Describe the solution you've chosen**

- Making the callback parameter optional.

**Describe alternatives you've considered**

- Using ESLint overrides on every line I call a handler but do not require a callback.

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../blob/master/CONTRIBUTING.md).
- [ ] The status checks are successful (continuous integration). Those can be seen below.
