### PR TITLE
feat: add schedule helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,30 @@ To use On-demand Builders, wrap your function handler with the `builder` functio
   export { handler }
   ```
 
+### Scheduled Functions (currently in beta)
+
+To use Scheduled Functions, wrap your function handler with the `schedule` function.
+
+- With JavaScript:
+
+  ```js
+  const { schedule } = require('@netlify/functions')
+
+  exports.handler = schedule('5 4 * * *', async () => {
+    console.log("It's 04:05 AM!")
+  })
+  ```
+
+- With TypeScript:
+
+  ```ts
+  import { schedule } from '@netlify/functions'
+
+  export const handler = schedule("5 4 * * *", async () => {
+    console.log("It's 04:05 AM!")
+  })
+  ```
+
 ### TypeScript typings
 
 This module exports typings for authoring Netlify Functions in TypeScript.

--- a/src/lib/schedule.ts
+++ b/src/lib/schedule.ts
@@ -1,0 +1,37 @@
+import type { Handler, HandlerContext, HandlerEvent } from '../function'
+
+type HandlerWithoutResponse = (event: HandlerEvent, context: HandlerContext) => Promise<void>
+
+/**
+ * Declares a function to run on a cron schedule.
+ * Not reachable via HTTP.
+ *
+ * @example
+ * ```
+ * export const handler = cron("5 4 * * *", async () => {
+ *   // ...
+ * })
+ * ```
+ *
+ * @param schedule expressed as cron string. see https://crontab.guru for help.
+ * @param handler
+ * @see https://docs.netlify.com/functions/<schedule>
+ * @tutorial https://announcement-blogpost
+ */
+const schedule =
+  (cron: string, handler: HandlerWithoutResponse): Handler =>
+  async (event, context) => {
+    try {
+      await handler(event, context)
+      return {
+        statusCode: 200,
+      }
+    } catch (error) {
+      return {
+        statusCode: 500,
+        body: String(error),
+      }
+    }
+  }
+
+export { schedule }

--- a/src/lib/schedule.ts
+++ b/src/lib/schedule.ts
@@ -1,6 +1,4 @@
-import type { Handler, HandlerContext, HandlerEvent } from '../function'
-
-type HandlerWithoutResponse = (event: HandlerEvent, context: HandlerContext) => Promise<void>
+import type { Handler } from '../function'
 
 /**
  * Declares a function to run on a cron schedule.
@@ -18,20 +16,6 @@ type HandlerWithoutResponse = (event: HandlerEvent, context: HandlerContext) => 
  * @see https://docs.netlify.com/functions/<schedule>
  * @tutorial https://announcement-blogpost
  */
-const schedule =
-  (cron: string, handler: HandlerWithoutResponse): Handler =>
-  async (event, context) => {
-    try {
-      await handler(event, context)
-      return {
-        statusCode: 200,
-      }
-    } catch (error) {
-      return {
-        statusCode: 500,
-        body: String(error),
-      }
-    }
-  }
+const schedule = (cron: string, handler: Handler): Handler => handler
 
 export { schedule }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,2 +1,3 @@
 export { builder } from './lib/builder'
+export { schedule } from './lib/schedule'
 export * from './function'


### PR DESCRIPTION
**Which problem is this pull request solving?**

This PR adds a `schedule` marker function that's used for ISC detection.

**Describe the solution you've chosen**

We decided to make `schedule` a no-op.
This requires developers to explicitly `return { statusCode: 200 }` or `{ statusCode: 500 }`, which is redundant & verbose given the usecase.
There is potential for simplified behaviour with the `schedule` helper, but we'd need to bring the `netlify.toml`-configured behaviour in-line with that first.