### PR TITLE
fix: use number type for memory limit

### DIFF
--- a/src/function/context.ts
+++ b/src/function/context.ts
@@ -7,7 +7,7 @@ export interface Context {
   functionName: string
   functionVersion: string
   invokedFunctionArn: string
-  memoryLimitInMB: string
+  memoryLimitInMB: number
   awsRequestId: string
   logGroupName: string
   logStreamName: string


### PR DESCRIPTION
**Which problem is this pull request solving?**

The runtime type of the field is `number`, as per `typeof`, at least in `netlify functions:serve` (cli v8.1.4)

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../blob/master/CONTRIBUTING.md).
- [ ] The status checks are successful (continuous integration). Those can be seen below. <- waiting on running the workflows
