### PR TITLE
Disallow synchronous handlers in type definition

### DIFF
--- a/src/function/handler.ts
+++ b/src/function/handler.ts
@@ -8,7 +8,7 @@ export interface HandlerCallback<ResponseType extends Response = Response> {
 }
 
 export interface BaseHandler<ResponseType extends Response = Response, C extends Context = Context> {
-  (event: Event, context: C, callback: HandlerCallback<ResponseType>): void | ResponseType | Promise<ResponseType>
+  (event: Event, context: C, callback: HandlerCallback<ResponseType>): void | Promise<ResponseType>
 }
 
 export type Handler = BaseHandler<Response, Context>


### PR DESCRIPTION
**Which problem is this pull request solving?**

The type definition of `Handler` (or `BaseHandler`, more specifically) allows handlers to by synchronous.

I wrote some Netlify functions, which worked as expected locally through Netlify CLI. On production, however, the function produced the following:

> error decoding lambda response: invalid status code returned from lambda: 0

This seems to have been caused by the functions returning a `Response` (directly) rather than a `Promise<Response>` in some branches. Synchronous handlers are allowed by (Netlify CLI, as well as) the type definition, but not actually by Netlify.

**List other issues or pull requests related to this problem**

(none that I could find)

**Describe the solution you've chosen**

Removed the synchronous version from the union that is the return type of `BaseHandler`.

**Describe alternatives you've considered**

Add support for synchronous handlers to the Netlify platform.

**Checklist**

- [x] I have read the [contribution guidelines](../blob/master/CONTRIBUTING.md).
- [x] The status checks are successful (continuous integration). Those can be seen below.
