### PR TITLE
refactor(authlify): expose `authlifyToken` directly

### DIFF
--- a/src/lib/secrets_helper.ts
+++ b/src/lib/secrets_helper.ts
@@ -135,7 +135,7 @@ const formatSecrets = (result: OneGraphSecretsResponse | undefined) => {
 
 type OneGraphPayload = { authlifyToken: string | undefined }
 
-export type HandlerEventWithOneGraph = HandlerEvent & { _oneGraph: OneGraphPayload }
+export type HandlerEventWithOneGraph = HandlerEvent & OneGraphPayload
 
 // Note: We may want to have configurable "sets" of secrets,
 // e.g. "dev" and "prod"
@@ -144,7 +144,7 @@ export const getSecrets = async (
 ): Promise<NetlifySecrets> => {
   // Allow us to get the token from event if present, else fallback to checking the env
   // eslint-disable-next-line no-underscore-dangle
-  const eventToken = (event as HandlerEventWithOneGraph)?._oneGraph?.authlifyToken
+  const eventToken = (event as HandlerEventWithOneGraph)?.authlifyToken
   const secretToken = eventToken || env.ONEGRAPH_AUTHLIFY_TOKEN
 
   if (!secretToken) {

--- a/src/lib/secrets_helper.ts
+++ b/src/lib/secrets_helper.ts
@@ -143,7 +143,6 @@ export const getSecrets = async (
   event?: HandlerEventWithOneGraph | HandlerEvent | undefined,
 ): Promise<NetlifySecrets> => {
   // Allow us to get the token from event if present, else fallback to checking the env
-  // eslint-disable-next-line no-underscore-dangle
   const eventToken = (event as HandlerEventWithOneGraph)?.authlifyToken
   const secretToken = eventToken || env.ONEGRAPH_AUTHLIFY_TOKEN
 


### PR DESCRIPTION
**Which problem is this pull request solving?**

We added the `authlifyToken` directly under the function payload in https://github.com/netlify/proxy/pull/719. This diff is an update to look up under the right key.

**List other issues or pull requests related to this problem**

https://github.com/netlify/proxy/pull/719

**Describe the solution you've chosen**

Example: I've fixed this by [...]

**Describe alternatives you've considered**

Example: Another solution would be [...]

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../blob/master/CONTRIBUTING.md).
- [x] The status checks are successful (continuous integration). Those can be seen below.
