### PR TITLE
fix: disallow synchronous responses

### DIFF
--- a/src/function/handler.ts
+++ b/src/function/handler.ts
@@ -8,7 +8,7 @@ export interface HandlerCallback<ResponseType extends Response = Response> {
 }
 
 export interface BaseHandler<ResponseType extends Response = Response, C extends Context = Context> {
-  (event: Event, context: C, callback?: HandlerCallback<ResponseType>): void | ResponseType | Promise<ResponseType>
+  (event: Event, context: C, callback?: HandlerCallback<ResponseType>): void | Promise<ResponseType>
 }
 
 export type Handler = BaseHandler<Response, Context>


### PR DESCRIPTION
Currently, our type definitions allow `Handler` to synchronously return a `Response`. This is supported by `ntl dev`, but not by Lambda - so it doesn't actually work when deployed. This PR moves the types in-line with Lambda behaviour. Further explained in #308.
