### PR TITLE
feat(graph): update graph helpers to work better with next.js

### DIFF
--- a/src/function/event.ts
+++ b/src/function/event.ts
@@ -25,4 +25,5 @@ export interface Event {
   multiValueQueryStringParameters: EventMultiValueQueryStringParameters | null
   body: string | null
   isBase64Encoded: boolean
+  netlifyGraphToken: string | undefined
 }

--- a/src/function/index.ts
+++ b/src/function/index.ts
@@ -2,5 +2,13 @@ export { Context as HandlerContext } from './context'
 export { Event as HandlerEvent } from './event'
 export { Handler, HandlerCallback } from './handler'
 export { Response as HandlerResponse } from './response'
-export { getSecrets, withSecrets, getNetlifyGraphToken, GraphTokenResponse, HasHeaders } from '../lib/graph'
+export {
+  getSecrets,
+  getSecretsForBuild,
+  withSecrets,
+  getNetlifyGraphToken,
+  getNetlifyGraphTokenForBuild,
+  GraphTokenResponse,
+  HasHeaders,
+} from '../lib/graph'
 export { NetlifySecrets } from '../lib/secrets_helper'

--- a/src/lib/graph.ts
+++ b/src/lib/graph.ts
@@ -5,8 +5,8 @@ import { Response } from '../function/response'
 
 import { getSecrets, NetlifySecrets } from './secrets_helper'
 // Fine-grained control during the preview, less necessary with a more proactive OneGraph solution
-export { getSecrets } from './secrets_helper'
-export { getNetlifyGraphToken, GraphTokenResponse, HasHeaders } from './graph_token'
+export { getSecrets, getSecretsForBuild } from './secrets_helper'
+export { getNetlifyGraphToken, getNetlifyGraphTokenForBuild, GraphTokenResponse, HasHeaders } from './graph_token'
 
 export interface ContextWithSecrets extends Context {
   secrets: NetlifySecrets

--- a/src/lib/secrets_helper.ts
+++ b/src/lib/secrets_helper.ts
@@ -102,7 +102,7 @@ const logErrors = function (errors: GraphTokenResponseError[]) {
   }
 }
 
-// We select for more than we typeically need here
+// We select for more than we typically need here
 // in order to allow for some metaprogramming for
 // consumers downstream. Also, the data is typically
 // static and shouldn't add any measurable overhead.

--- a/src/lib/secrets_helper.ts
+++ b/src/lib/secrets_helper.ts
@@ -1,5 +1,5 @@
 import { graphRequest } from './graph_request'
-import { getNetlifyGraphToken, GraphTokenResponseError, HasHeaders } from './graph_token'
+import { getNetlifyGraphToken, getNetlifyGraphTokenForBuild, GraphTokenResponseError, HasHeaders } from './graph_token'
 
 const services = {
   gitHub: null,
@@ -102,23 +102,11 @@ const logErrors = function (errors: GraphTokenResponseError[]) {
   }
 }
 
-// Note: We may want to have configurable "sets" of secrets,
-// e.g. "dev" and "prod"
-export const getSecrets = async (event?: HasHeaders | null | undefined): Promise<NetlifySecrets> => {
-  const graphTokenResponse = getNetlifyGraphToken(event, true)
-  const graphToken = graphTokenResponse.token
-  if (!graphToken) {
-    if (graphTokenResponse.errors) {
-      logErrors(graphTokenResponse.errors)
-    }
-    return {}
-  }
-
-  // We select for more than we typeically need here
-  // in order to allow for some metaprogramming for
-  // consumers downstream. Also, the data is typically
-  // static and shouldn't add any measurable overhead.
-  const doc = `query FindLoggedInServicesQuery {
+// We select for more than we typeically need here
+// in order to allow for some metaprogramming for
+// consumers downstream. Also, the data is typically
+// static and shouldn't add any measurable overhead.
+const findLoggedInServicesQuery = `query FindLoggedInServicesQuery {
     me {
       serviceMetadata {
         loggedInServices {
@@ -143,13 +131,40 @@ export const getSecrets = async (event?: HasHeaders | null | undefined): Promise
     }
   }`
 
-  const body = JSON.stringify({ query: doc })
+const getSecretsForToken = async (token: string): Promise<NetlifySecrets> => {
+  const body = JSON.stringify({ query: findLoggedInServicesQuery })
 
   // eslint-disable-next-line node/no-unsupported-features/node-builtins
-  const resultBody = await graphRequest(graphToken, new TextEncoder().encode(body))
+  const resultBody = await graphRequest(token, new TextEncoder().encode(body))
   const result: GraphSecretsResponse = JSON.parse(resultBody)
 
   const newSecrets = formatSecrets(result)
 
   return newSecrets
+}
+
+export const getSecrets = async (event?: HasHeaders | null | undefined): Promise<NetlifySecrets> => {
+  const graphTokenResponse = getNetlifyGraphToken(event, true)
+  const graphToken = graphTokenResponse.token
+  if (!graphToken) {
+    if (graphTokenResponse.errors) {
+      logErrors(graphTokenResponse.errors)
+    }
+    return {}
+  }
+
+  return await getSecretsForToken(graphToken)
+}
+
+export const getSecretsForBuild = async (): Promise<NetlifySecrets> => {
+  const graphTokenResponse = getNetlifyGraphTokenForBuild()
+  const graphToken = graphTokenResponse.token
+  if (!graphToken) {
+    if (graphTokenResponse.errors) {
+      logErrors(graphTokenResponse.errors)
+    }
+    return {}
+  }
+
+  return await getSecretsForToken(graphToken)
 }


### PR DESCRIPTION
Follow up to https://github.com/netlify/functions/pull/326

Exports two new functions `getSecretsForBuild` and `getNetlifyGraphTokenForBuild` that can be used with `getStaticProps` in next.js (along with https://github.com/netlify/netlify-plugin-nextjs/pull/1525). They can also be used during a normal netlify build.

Also falls back to reading the token from the environment variable in dev mode since next.js does not run the header-injection code from the netlify cli in dev mode.