### PR TITLE
feat: Allow any status code in builder functions

### DIFF
--- a/src/lib/builder.ts
+++ b/src/lib/builder.ts
@@ -7,7 +7,7 @@ import { Response, BuilderResponse } from '../function/response'
 import { BUILDER_FUNCTIONS_FLAG, HTTP_STATUS_METHOD_NOT_ALLOWED, HTTP_STATUS_OK, METADATA_VERSION } from './consts'
 
 const augmentResponse = (response: BuilderResponse) => {
-  if (!response || response.statusCode !== HTTP_STATUS_OK) {
+  if (!response) {
     return response
   }
   const metadata = { version: METADATA_VERSION, builder_function: BUILDER_FUNCTIONS_FLAG, ttl: response.ttl ?? 0 }

--- a/src/lib/builder.ts
+++ b/src/lib/builder.ts
@@ -4,7 +4,7 @@ import { HandlerContext, HandlerEvent } from '../function'
 import { BuilderHandler, Handler, HandlerCallback } from '../function/handler'
 import { Response, BuilderResponse } from '../function/response'
 
-import { BUILDER_FUNCTIONS_FLAG, HTTP_STATUS_METHOD_NOT_ALLOWED, HTTP_STATUS_OK, METADATA_VERSION } from './consts'
+import { BUILDER_FUNCTIONS_FLAG, HTTP_STATUS_METHOD_NOT_ALLOWED, METADATA_VERSION } from './consts'
 
 const augmentResponse = (response: BuilderResponse) => {
   if (!response) {

--- a/test/builder.js
+++ b/test/builder.js
@@ -39,7 +39,7 @@ test('Injects the metadata object into a synchronous handler', async (t) => {
   t.deepEqual(response, { ...originalResponse, ...METADATA_OBJECT })
 })
 
-test('Does not inject the metadata object for non-200 responses', async (t) => {
+test('Injects the metadata object for non-200 responses', async (t) => {
   const originalResponse = {
     body: ':thumbsdown:',
     statusCode: 404,
@@ -55,7 +55,7 @@ test('Does not inject the metadata object for non-200 responses', async (t) => {
   }
   const response = await invokeLambda(builder(myHandler))
 
-  t.deepEqual(response, originalResponse)
+  t.deepEqual(response, { ...originalResponse, ...METADATA_OBJECT })
 })
 
 test('Returns a 405 error for requests using the POST method', async (t) => {


### PR DESCRIPTION
🎉 Thanks for sending this pull request! 🎉

**Which problem is this pull request solving?**

There are requests to cache any status codes for builder functions.

**List other issues or pull requests related to this problem**

https://github.com/netlify/pillar-runtime/issues/443

**Describe the solution you've chosen**

We're removing the status check here, but our invocation proxy still has some checks in place.

**Describe alternatives you've considered**

n/a

**Checklist**

- [x] I have read the [contribution guidelines](../blob/master/CONTRIBUTING.md).
- [ ] The status checks are successful (continuous integration). Those can be seen below.
