### PR TITLE
feat: add `preferStatic` type to config

### DIFF
--- a/src/function/v2.ts
+++ b/src/function/v2.ts
@@ -25,7 +25,7 @@ interface ConfigWithPath extends BaseConfig {
    *
    * {@link} https://ntl.fyi/func-routing
    */
-  path: Path | Path[]
+  path?: Path | Path[]
 
   schedule?: never
 }

--- a/src/function/v2.ts
+++ b/src/function/v2.ts
@@ -22,6 +22,8 @@ interface ConfigWithPath extends BaseConfig {
   /**
    * One or more URL paths for which the function will run. Paths must begin
    * with a forward slash.
+   *
+   * {@link} https://ntl.fyi/func-routing
    */
   path: Path | Path[]
 

--- a/src/function/v2.ts
+++ b/src/function/v2.ts
@@ -1,13 +1,43 @@
 export type { Context } from '@netlify/serverless-functions-api'
 
 type Path = `/${string}`
-
 type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS'
-
 type CronSchedule = string
 
-export interface Config {
-  path?: Path | Path[]
+interface BaseConfig {
+  /**
+   * Configures the function to serve any static files that match the request
+   * URL and render the function only if no matching files exist.
+   */
+  preferStatic?: boolean
+
+  /**
+   * Limits the HTTP methods for which the function will run. If not set, the
+   * function will run for all supported methods.
+   */
   method?: HTTPMethod | HTTPMethod[]
-  schedule?: CronSchedule
 }
+
+interface ConfigWithPath extends BaseConfig {
+  /**
+   * One or more URL paths for which the function will run. Paths must begin
+   * with a forward slash.
+   */
+  path: Path | Path[]
+
+  schedule?: never
+}
+
+interface ConfigWithSchedule extends BaseConfig {
+  path?: never
+
+  /**
+   * Cron expression representing the schedule at which the function will be
+   * automatically invoked.
+   *
+   * {@link} https://ntl.fyi/sched-func
+   */
+  schedule: CronSchedule
+}
+
+export type Config = ConfigWithPath | ConfigWithSchedule


### PR DESCRIPTION
**Which problem is this pull request solving?**

Adds a new `preferStatic` type to the functions config.

Also, makes the `path` and `schedule` properties mutually exclusive.

Finally, it adds some JSDoc comments to each property.