### PR TITLE
fix: allow returning `Response` objects from function Handlers

### DIFF
--- a/src/function/handler.ts
+++ b/src/function/handler.ts
@@ -2,13 +2,13 @@ import type { HandlerContext } from './handler_context.js'
 import type { HandlerEvent } from './handler_event.js'
 import type { HandlerResponse, BuilderResponse, StreamingResponse } from './handler_response.js'
 
-export interface HandlerCallback<ResponseType extends HandlerResponse = HandlerResponse> {
+export interface HandlerCallback<ResponseType extends HandlerResponse | Response = HandlerResponse> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (error: any, response: ResponseType): void
 }
 
 export interface BaseHandler<
-  ResponseType extends HandlerResponse = HandlerResponse,
+  ResponseType extends HandlerResponse | Response = HandlerResponse,
   C extends HandlerContext = HandlerContext,
 > {
   (event: HandlerEvent, context: C, callback?: HandlerCallback<ResponseType>): void | Promise<ResponseType>
@@ -18,7 +18,7 @@ export interface BackgroundHandler<C extends HandlerContext = HandlerContext> {
   (event: HandlerEvent, context: C): void | Promise<void>
 }
 
-export type Handler = BaseHandler<HandlerResponse, HandlerContext>
+export type Handler = BaseHandler<HandlerResponse | Response, HandlerContext>
 export type BuilderHandler = BaseHandler<BuilderResponse, HandlerContext>
 
 export interface StreamingHandler {

--- a/test/types/Handler.test-d.ts
+++ b/test/types/Handler.test-d.ts
@@ -1,4 +1,4 @@
-import { expectError } from 'tsd'
+import { expectAssignable, expectError } from 'tsd'
 
 import { Handler } from '../../src/main.js'
 
@@ -9,3 +9,9 @@ expectError(() => {
     // void
   }
 })
+
+expectAssignable<Handler>(() => Promise.resolve({ statusCode: 200 }));
+
+expectAssignable<Handler>(() => Promise.resolve(new Response("hello")));
+
+expectError<Handler>(() => Promise.resolve({ missing: "status code" }));


### PR DESCRIPTION
**Which problem is this pull request solving?**

Per the [functions documentation][1], it seems like you should be able to return a standard `Response` object from function handlers. However, the existing types only allows a user to return a `HandlerResponse` object.

**List other issues or pull requests related to this problem**

It looks like https://github.com/netlify/functions/pull/351 also addresses this issue, but that PR is a little stale at this point.

**Describe the solution you've chosen**

This updates the `Handler` type to accept both `HandlerResponse` and `Response` as a return value.

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../blob/master/CONTRIBUTING.md).
- [ ] The status checks are successful (continuous integration). Those can be seen below.



[1]: https://docs.netlify.com/functions/get-started/?fn-language=ts#synchronous-function