### PR TITLE
feat: support custom raw logger

### DIFF
--- a/src/internal.ts
+++ b/src/internal.ts
@@ -2,4 +2,4 @@
 // and only meant for consumption by Netlify Teams.
 // While we try to adhere to semver, this file is not considered part of the public API.
 
-export { systemLogger, LogLevel } from './lib/system_logger.js'
+export { systemLogger, LogLevel, StructuredLogger } from './lib/system_logger.js'

--- a/src/lib/system_logger.ts
+++ b/src/lib/system_logger.ts
@@ -18,6 +18,7 @@ export enum LogLevel {
   Debug = 1,
   Log,
   Error,
+  Silent = Infinity,
 }
 
 class SystemLogger {
@@ -30,10 +31,6 @@ class SystemLogger {
   }
 
   private doLog(logger: typeof console.log, message: string) {
-    if (env.NETLIFY_DEV && !env.NETLIFY_ENABLE_SYSTEM_LOGGING) {
-      return
-    }
-
     logger(systemLogTag, JSON.stringify({ msg: message, fields: this.fields }))
   }
 


### PR DESCRIPTION
**Which problem is this pull request solving?**

This PR proposes two changes to the API of the recently-added system logger:

1. Remove the `NETLIFY_DEV` and `NETLIFY_ENABLE_SYSTEM_LOGGING` environment variables in favour of a new `Silent` log level. If we want to silence the logger from the CLI or any other consumer applications, we should let them configure that behaviour themselves rather than making the logger rely on their internals.

    Moreover, this lets the CLI more easily configure this behaviour conditionally — e.g. show system logs if the `--debug` flag has been used, which is what we do currently with edge functions.

    ```js
    import { systemLogger, LogLevel } from "@netlify/functions/dist/internal.js"

    const logger = systemLogger.withLogLevel(flags.debug ? LogLevel.Log : LogLevel.Silent)

    logger.log("Hello")
    ```

2. Allow consumers to specify a custom raw logger that replaces the default `globalThis.console` methods. We can use this to plug this logger into the system logger that we expose to build plugins, where we want to call `utils.systemLog` and not `console.log` on the resulting payload.

    I'm exporting the underlying class (which I've renamed to `StructuredLogger`, because I think it's more accurate), which accepts a raw logger in the constructor.

    ```js
    import { LogLevel, StructuredLogger } from "@netlify/functions/dist/internal.js"

    export const onPreBuild = ({ utils }) => {
      const logger = new StructuredLogger(LogLevel.Log, utils.systemLog)

      logger.withFields({ foo: "bar" }).log("This is a system log")
    }
    ```