### PR TITLE
fix: skip purgeCache in local dev

### DIFF
--- a/src/lib/purge_cache.ts
+++ b/src/lib/purge_cache.ts
@@ -29,6 +29,7 @@ interface PurgeAPIPayload {
   site_slug?: string
 }
 
+// eslint-disable-next-line complexity
 export const purgeCache = async (options: PurgeCacheOptions = {}) => {
   if (globalThis.fetch === undefined) {
     throw new Error(
@@ -41,6 +42,12 @@ export const purgeCache = async (options: PurgeCacheOptions = {}) => {
     deploy_alias: options.deployAlias,
   }
   const token = env.NETLIFY_PURGE_API_TOKEN || options.token
+
+  if (env.NETLIFY_LOCAL && !token) {
+    const scope = options.tags?.length ? `for tags ${options.tags?.join(', ')} ` : ''
+    console.log(`Skipping purgeCache${scope} in local development.`)
+    return
+  }
 
   if ('siteSlug' in options) {
     payload.site_slug = options.siteSlug

--- a/src/lib/purge_cache.ts
+++ b/src/lib/purge_cache.ts
@@ -44,7 +44,7 @@ export const purgeCache = async (options: PurgeCacheOptions = {}) => {
   const token = env.NETLIFY_PURGE_API_TOKEN || options.token
 
   if (env.NETLIFY_LOCAL && !token) {
-    const scope = options.tags?.length ? `for tags ${options.tags?.join(', ')} ` : ''
+    const scope = options.tags?.length ? ` for tags ${options.tags?.join(', ')}` : ''
     console.log(`Skipping purgeCache${scope} in local development.`)
     return
   }


### PR DESCRIPTION
**Which problem is this pull request solving?**

Currently running `purgeCache` in local development throws an error. While I wouldn't expect it to actually purge anything (because there's no cache anyway), this prevents us running dev for any site that does use this.

**Describe the solution you've chosen**

Log a message and return if called in local dev without a token. If a token is passed I assume the user knows what they're doing and wants it to work for real.

**Describe alternatives you've considered**

Example: Another solution would be [...]

**Checklist**

Please add a `x` inside each checkbox:

- [ ] I have read the [contribution guidelines](../blob/master/CONTRIBUTING.md).
- [ ] The status checks are successful (continuous integration). Those can be seen below.
