### PR TITLE
feat: add dedicated logTrace function to the system logger with it's own prefix

### DIFF
--- a/src/lib/system_logger.ts
+++ b/src/lib/system_logger.ts
@@ -1,6 +1,7 @@
 import { env } from 'process'
 
 const systemLogTag = '__nfSystemLog'
+const openTelemetryLogTag = '__nfOpenTelemetryLog'
 
 const serializeError = (error: Error): Record<string, unknown> => {
   const cause = error?.cause instanceof Error ? serializeError(error.cause) : error.cause
@@ -35,6 +36,15 @@ class SystemLogger {
     }
 
     logger(systemLogTag, JSON.stringify({ msg: message, fields: this.fields }))
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  logTrace(span: Record<string, unknown>) {
+    if (env.NETLIFY_DEV && !env.NETLIFY_ENABLE_SYSTEM_LOGGING) {
+      return
+    }
+
+    console.log(openTelemetryLogTag, JSON.stringify(span))
   }
 
   log(message: string) {

--- a/test/unit/system_logger.js
+++ b/test/unit/system_logger.js
@@ -1,4 +1,4 @@
-const process = require("process")
+const process = require('process')
 
 const test = require('ava')
 
@@ -43,15 +43,21 @@ test('Local Dev', (t) => {
   const logs = []
   console.log = (...message) => logs.push(message)
   systemLogger.log('hello!')
-  t.is(logs.length, 1)
-
-  process.env.NETLIFY_DEV= "true"
-  systemLogger.log('hello!')
-  t.is(logs.length, 1)
-
-  process.env.NETLIFY_ENABLE_SYSTEM_LOGGING= "true"
-  systemLogger.log('hello!')
+  systemLogger.logTrace({ span_id: '123' })
   t.is(logs.length, 2)
+
+  process.env.NETLIFY_DEV = 'true'
+  systemLogger.log('hello!')
+  systemLogger.logTrace({ span_id: '456' })
+  t.is(logs.length, 2)
+
+  process.env.NETLIFY_ENABLE_SYSTEM_LOGGING = 'true'
+  systemLogger.log('hello!')
+  systemLogger.logTrace({ span_id: '789' })
+  t.is(logs.length, 4)
+
+  t.deepEqual(logs[1], ['__nfOpenTelemetryLog', '{"span_id":"123"}'])
+  t.deepEqual(logs[3], ['__nfOpenTelemetryLog', '{"span_id":"789"}'])
 
   delete process.env.NETLIFY_DEV
   delete process.env.NETLIFY_ENABLE_SYSTEM_LOGGING


### PR DESCRIPTION
🎉 Thanks for sending this pull request! 🎉

This is part of https://linear.app/netlify/issue/COM-475/build-own-system-logging-prefix-for-traces-logged-with-the-system

Let's see if we want to merge this or not. I've just created a draft with the changes – we can always decide to not merge this.