### PR TITLE
feat: add custom rate limit types

### DIFF
--- a/src/function/v2.ts
+++ b/src/function/v2.ts
@@ -3,14 +3,12 @@ export type { Context } from '@netlify/serverless-functions-api'
 type Path = `/${string}`
 type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS'
 type CronSchedule = string
-type RateLimitAlgorithm = 'sliding_window'
 type RateLimitAggregator = 'domain' | 'ip'
 type RateLimitAction = 'rate_limit' | 'rewrite'
 
 interface RateLimitConfig {
   action?: RateLimitAction
   aggregateBy?: RateLimitAggregator | RateLimitAggregator[]
-  algorithm?: RateLimitAlgorithm
   to?: string
   windowSize: number
 }

--- a/src/function/v2.ts
+++ b/src/function/v2.ts
@@ -3,6 +3,17 @@ export type { Context } from '@netlify/serverless-functions-api'
 type Path = `/${string}`
 type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS'
 type CronSchedule = string
+type RateLimitAlgorithm = 'sliding_window'
+type RateLimitAggregator = 'domain' | 'ip'
+type RateLimitAction = 'rate_limit' | 'rewrite'
+
+interface RateLimitConfig {
+  action?: RateLimitAction
+  aggregateBy?: RateLimitAggregator | RateLimitAggregator[]
+  algorithm?: RateLimitAlgorithm
+  to?: string
+  windowSize: number
+}
 
 interface BaseConfig {
   /**
@@ -16,6 +27,8 @@ interface BaseConfig {
    * function will run for all supported methods.
    */
   method?: HTTPMethod | HTTPMethod[]
+
+  rateLimit?: RateLimitConfig
 }
 
 interface ConfigWithPath extends BaseConfig {


### PR DESCRIPTION
Base types for custom rate limit config type inference (almost forgot). Basically a dried out version of https://github.com/netlify/zip-it-and-ship-it/blob/main/src/rate_limit.ts, but let me know if you think I should just use the original one instead.

Related to ADN-294

Will do the same for edge-functions after this one gets through