### PR TITLE
fix: if the purge api call fails, include the api response body in the thrown error's message

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,6 +6,7 @@ module.exports = {
   extends: '@netlify/eslint-config-node',
   rules: {
     'max-statements': 'off',
+    'max-lines': 'off',
   },
   overrides: [
     ...overrides,

--- a/src/lib/purge_cache.ts
+++ b/src/lib/purge_cache.ts
@@ -38,6 +38,14 @@ export const purgeCache = async (options: PurgeCacheOptions = {}) => {
     )
   }
 
+  const { siteID } = options as PurgeCacheOptionsWithSiteID
+  const { siteSlug } = options as PurgeCacheOptionsWithSiteSlug
+  const { domain } = options as PurgeCacheOptionsWithDomain
+
+  if ((siteID && siteSlug) || (siteID && domain) || (siteSlug && domain)) {
+    throw new Error('Can only pass one of either "siteID", "siteSlug", or "domain"')
+  }
+
   const payload: PurgeAPIPayload = {
     cache_tags: options.tags,
     deploy_alias: options.deployAlias,
@@ -50,22 +58,20 @@ export const purgeCache = async (options: PurgeCacheOptions = {}) => {
     return
   }
 
-  if ('siteSlug' in options) {
-    payload.site_slug = options.siteSlug
-  } else if ('domain' in options) {
-    payload.domain = options.domain
+  if (siteSlug) {
+    payload.site_slug = siteSlug
+  } else if (domain) {
+    payload.domain = domain
   } else {
     // The `siteID` from `options` takes precedence over the one from the
     // environment.
-    const siteID = options.siteID || env.SITE_ID
+    payload.site_id = siteID || env.SITE_ID
 
-    if (!siteID) {
+    if (!payload.site_id) {
       throw new Error(
         'The Netlify site ID was not found in the execution environment. Please supply it manually using the `siteID` property.',
       )
     }
-
-    payload.site_id = siteID
   }
 
   if (!token) {

--- a/src/lib/purge_cache.ts
+++ b/src/lib/purge_cache.ts
@@ -91,6 +91,13 @@ export const purgeCache = async (options: PurgeCacheOptions = {}) => {
   })
 
   if (!response.ok) {
-    throw new Error(`Cache purge API call returned an unexpected status code: ${response.status}`)
+    let text
+    try {
+      text = await response.text()
+    } catch {}
+    if (text) {
+      throw new Error(`Cache purge API call was unsuccessful.\nStatus: ${response.status}\nBody: ${text}`)
+    }
+    throw new Error(`Cache purge API call was unsuccessful.\nStatus: ${response.status}`)
   }
 }


### PR DESCRIPTION
Right now if the purge call returns a non-ok response, the error message does not include the response, which makes it hard for the user of the api to figure out what the issue is